### PR TITLE
Fix mergeWithoutOverwrite with hasOwnProperty

### DIFF
--- a/lib/cli-engine/config-array/config-array.js
+++ b/lib/cli-engine/config-array/config-array.js
@@ -127,8 +127,8 @@ function isNonNullObject(x) {
 /**
  * Merge two objects.
  *
- * Assign every property values of `y` to `x` if `x` doesn't have the property.
- * If `x`'s property value is an object, it does recursive.
+ * Assign every property values of `source` to `target` if `target` doesn't have the property.
+ * If `target`'s property value is an object, it does recursive.
  * @param {Object} target The destination to merge
  * @param {Object|undefined} source The source to merge.
  * @returns {void}
@@ -139,13 +139,15 @@ function mergeWithoutOverwrite(target, source) {
     }
 
     for (const key of Object.keys(source)) {
-        if (key === "__proto__") {
+        if (!Object.prototype.hasOwnProperty.call(source, key)) {
             continue;
         }
 
-        if (isNonNullObject(target[key])) {
-            mergeWithoutOverwrite(target[key], source[key]);
-        } else if (target[key] === void 0) {
+        if (Object.prototype.hasOwnProperty.call(target, key)) {
+            if (isNonNullObject(target[key])) {
+                mergeWithoutOverwrite(target[key], source[key]);
+            }
+        } else {
             if (isNonNullObject(source[key])) {
                 target[key] = Array.isArray(source[key]) ? [] : {};
                 mergeWithoutOverwrite(target[key], source[key]);


### PR DESCRIPTION
Only merge to target if the key fails the hasOwnProperty check, rather than just check for undefined.

Replace the `key === "__proto__"` check with a hasOwnProperty check for source.

We can still use an undefined check when deciding if to copy source[key] to target[key] as by this stage both have been checked with hasOwnProperty.